### PR TITLE
Dealing with different types of imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,133 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+.idea/
+
+# testing files
+/run_pystats.bash

--- a/PyStats.py
+++ b/PyStats.py
@@ -1,79 +1,68 @@
 import argparse
+# Dashboard imports
 import os
-import pathlib
-from collections import Counter 
-import re
+from collections import Counter
 
-
-#Dashboard imports
-from rich.console import Console
-from rich.panel import Panel
-from rich.markdown import Markdown
-from rich.align import Align
-import os
-
-#Fine path called d:\1.Autohotkey\.Python\Project Folders\portswwww.py
-from rich.console import Console
+from rich import pretty, print
+# Fine path called d:\1.Autohotkey\.Python\Project Folders\portswwww.py
 from rich.traceback import install as install_traceback
-from rich import print, pretty
-import time
-from rich.panel import Panel
-#Usage: print(Panel.fit("Hello, [red]World!", title="Welcome", subtitle="Thank you"))
+
+# Usage: print(Panel.fit("Hello, [red]World!", title="Welcome", subtitle="Thank you"))
 pretty.install()
 install_traceback(show_locals=False)
-#Dashboard imports \\ or pretty imports?
+# Dashboard imports \\ or pretty imports?
 
 # Initializing Parser
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-df", help="Input Absolute Path to Directory or File")
-    #df is directory or file it will kinda figure out byitself assuming theirs only 2 files in the dir and u do -neglect
+    # df is directory or file it will kinda figure out itself assuming theirs only 2 files in
+    # the dir and u do -neglect
     parser.add_argument('-onefile', help="Input Absolute Path to File to Analyze")
-    parser.add_argument("-neglect", help="Input Absolute Path to File to Ignore ONLY IN DIRECTORY") 
-    #Debug argument to print out the file names
+    parser.add_argument("-neglect", help="Input Absolute Path to File to Ignore ONLY IN DIRECTORY")
+    # Debug argument to print out the file names
     path = parser.parse_args()
-    #2 Varibles 
-    #path.df
-    #path.onefile ignores everything and makes sure u have just onefile ur scanning
-    #Path.neglect
-    
+    # 2 Variables
+    # path.df
+    # path.onefile ignores everything and makes sure u have just onefile ur scanning
+    # Path.neglect
+
     if path.onefile:
         paths = [path.onefile]
     else:
-        #Determine if its a directory or file
+        # Determine if it's a directory or file
         if os.path.isdir(path.df):
-            #If its a directory get all absolute paths of files in it ending with py
+            # If it's a directory get all absolute paths of files in it ending with py
             paths = []
-            for dirpath,_,filenames in os.walk(path.df):
+            for dir_path, _, filenames in os.walk(path.df):
                 for f in filenames:
                     if f.endswith('.py'):
-                        paths.append(os.path.abspath(os.path.join(dirpath, f)))
-            #remove neglect from paths
+                        paths.append(os.path.abspath(os.path.join(dir_path, f)))
+            # remove neglect from paths
             if path.neglect is not None:
                 for line in paths:
                     original_line = line
-                    line = line.replace("\\","/")
+                    line = line.replace("\\", "/")
                     if path.neglect in line:
                         paths.remove(original_line)
         else:
             paths = [path.df]
-    #That ends classification of the file
-    
-    
-    
+    # That ends classification of the file
+
+
 class Stat:
     def __init__(self, directory) -> None:
         self.directory = directory
-        #Add .py to directory if not there
+        # Add .py to directory if not there
         if not self.directory[-1].endswith('.py'):
             self.directory[-1] += '.py'
-        #Check if file exists
+        # Check if file exists
         if not os.path.exists(self.directory[-1]):
             print("[red]File does not exist")
             exit()
-        #The Neglect keyword aint needed cause its already delt in the if statment from before 
-        
+        # The Neglect keyword ain't needed because it's already delt in the if statement from before
+
     def scrape_imports(self):
         imports_ = []
         real_imports = []
@@ -83,7 +72,7 @@ class Stat:
                 with open(path, encoding='utf8') as f:
                     for line in f:
                         if line.startswith('import'):
-                            imports_.append(line)   
+                            imports_.append(line)
                         elif line.startswith('from'):
                             imports_.append(line)
         else:
@@ -94,14 +83,14 @@ class Stat:
                         imports_.append(line)
                     elif line.startswith('from'):
                         imports_.append(line)
-        
+
         for line in imports_:
             real_imports.append(line.strip())
-        
+
         return real_imports
-    
+
     def line_count(self):
-        #if its a directory return the lines in a dict with the file name as the key
+        # if it's a directory return the lines in a dict with the file name as the key
         if len(self.directory) > 1:
             line_count = {}
             for path in self.directory:
@@ -110,31 +99,30 @@ class Stat:
         else:
             with open(self.directory[0], encoding='utf8') as f:
                 line_count = len(f.readlines())
-        
-        return line_count
-    
-    def most_used_varible(self):
-        varibles = self.scrape_varibles()
-        varible_count = Counter(varibles)
-        dictionaryy = {}
-        for key, value in varible_count.items():
-            dictionaryy[key] = value
-        most_used_varible = max(dictionaryy, key=dictionaryy.get)
-        return most_used_varible, dictionaryy[most_used_varible]
-        
-        
-    def scrape_varibles(self, full_line_of_varible=False):
-        varibles = []
-        var = {}
-        with open(self.directory[0], encoding='utf8') as f:
-            for line in f:
-                if ' = ' in line:
-                    if full_line_of_varible:
-                        varibles.append(line)
-                    varibles.append(line.split()[0])
-                        
-        return varibles
 
+        return line_count
+
+    def most_used_variable(self):
+        variables = self.scrape_variables()
+        variable_count = Counter(variables)
+        dictionary = {}
+        for key, value in variable_count.items():
+            dictionary[key] = value
+        most_used_variable = max(dictionary, key=dictionary.get)
+        return most_used_variable, dictionary[most_used_variable]
+
+    def scrape_variables(self, full_line_of_variable=False):
+        variables = []
+        var = {}
+        for i in self.directory:
+            with open(i, encoding='utf8') as f:
+                for line in f:
+                    if ' = ' in line:
+                        if full_line_of_variable:
+                            variables.append(line)
+                        variables.append(line.split()[0])
+
+        return variables
 
     def get_import_names(self):
         imports = self.scrape_imports()
@@ -144,14 +132,12 @@ class Stat:
                 import_names.append(line.split()[1])
             elif line.startswith('from'):
                 import_names.append(line.split()[3])
-                
-        return import_names
-                
 
-            
-info = Stat(paths)    
-        
-    
+        return import_names
+
+
+info = Stat(paths)
+
 print(info.line_count(),
-      info.most_used_varible(),
-      info.scrape_varibles())
+      info.most_used_variable(),
+      info.scrape_variables())


### PR DESCRIPTION
Several import types to deal with include,
- [ ] `from package import module`
- [ ] `from package import module1, module2`
- [ ] `from package import module1 as _module1, module2 as _module2`
- [ ] `from . import package`
- [ ] `from . import package1, package2`
- [ ] `from package.subpackage import file`
- [ ] `import package`
- [ ] `import package as _package`
- [ ] Imports in `try/except` block
- [ ] Avoid `from` and `import` in strings/docstrings.